### PR TITLE
chore: convert graphql to API calls

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -19,9 +19,6 @@ KIMA_BACKEND_FEE_URL=https://fee.kima.network
 # Kima RPC node provider
 KIMA_BACKEND_NODE_PROVIDER=https://rpc.kima.network
 
-# Kima GraphQL endpoint
-KIMA_BACKEND_NODE_PROVIDER_GRAPHQL=https://graphql.kima.network/v1/graphql
-
 # Kima API endpoint
 KIMA_BACKEND_NODE_PROVIDER_QUERY=https://api.kima.network
 
@@ -60,9 +57,6 @@ KIMA_BACKEND_FEE_URL=https://fee.sardis.kima.network
 
 # Kima RPC node provider
 KIMA_BACKEND_NODE_PROVIDER=https://rpc-testnet.kima.finance
-
-# Kima GraphQL endpoint
-KIMA_BACKEND_NODE_PROVIDER_GRAPHQL=https://graphql.sardis.kima.network/v1/graphql
 
 # Kima API endpoint
 KIMA_BACKEND_NODE_PROVIDER_QUERY=https://api.sardis.kima.network

--- a/src/routes/tx.ts
+++ b/src/routes/tx.ts
@@ -2,7 +2,12 @@ import { Request, Response, Router } from 'express'
 import { fetchWrapper } from '../fetch-wrapper'
 import { param } from 'express-validator'
 import { validateRequest } from '../middleware/validation'
-import { TransactionStatus } from '../types/transaction-status'
+import {
+  ApiLiquidityTxStatusResponse,
+  ApiTxStatusResponse,
+  GraphqlLiquidityTxStatusResponse,
+  GraphqlTxStatusResponse
+} from '../types/transaction-status'
 
 const txRouter = Router()
 
@@ -88,33 +93,42 @@ txRouter.get(
     const { txId } = req.params
 
     try {
-      const result = await fetchWrapper.post(
-        process.env.KIMA_BACKEND_NODE_PROVIDER_GRAPHQL as string,
-        {
-          query: `
-            query TransactionDetailsKima($txId: bigint) {
-              liquidity_transaction_data(where: { tx_id: { _eq: $txId } }, limit: 1) {
-                failreason
-                pullfailcount
-                pullhash
-                releasefailcount
-                releasehash
-                txstatus
-                amount
-                creator
-                chain
-                providerchainaddress
-                symbol
-                tx_id
-                kimahash
-              }
-            }`,
-          variables: {
-            txId: BigInt(txId)
+      const response = await fetchWrapper.get<ApiLiquidityTxStatusResponse>(
+        `${process.env.KIMA_BACKEND_NODE_PROVIDER_QUERY}/kima-finance/kima-blockchain/transaction/liquidity_transaction_data/${txId}`
+      )
+      if (typeof response === 'string') {
+        const message = `failed to get status for transaction ${txId}`
+        console.error(message, response)
+        res.status(500).json({ message })
+        return
+      }
+
+      // convert to GraphQL response for backwards compatibility
+      const data = response.LiquidityTransactionData
+      const output = {
+        data: {
+          liquidity_transaction_data: {
+            failreason: data.failReason,
+            pullfailcount: Number(data.pullFailCount),
+            pullhash: data.tssPullHash,
+            releasefailcount: Number(data.releaseFailCount),
+            releasehash: data.tssReleaseHash,
+            txstatus: data.status,
+            amount: Number(data.amount),
+            creator: data.creator,
+            originaddress: data.providerChainAddress,
+            originchain: data.chain,
+            originsymbol: data.symbol,
+            targetsymbol: data.symbol,
+            targetaddress: data.providerKimaAddress,
+            targetchain: data.chain,
+            tx_id: data.index,
+            kimahash: data.kimaTxHash
           }
         }
-      )
-      res.status(200).send(result as TransactionStatus)
+      } satisfies GraphqlLiquidityTxStatusResponse
+
+      res.status(200).json(output)
     } catch (e) {
       console.error(e)
       res.status(500).send(`failed to get status for transaction ${txId}`)
@@ -204,36 +218,42 @@ txRouter.get(
     const { txId } = req.params
 
     try {
-      const result = await fetchWrapper.post(
-        process.env.KIMA_BACKEND_NODE_PROVIDER_GRAPHQL as string,
-        {
-          query: `
-            query TransactionDetailsKima($txId: bigint) {
-              transaction_data(where: { tx_id: { _eq: $txId } }, limit: 1) {
-                failreason
-                pullfailcount
-                pullhash
-                releasefailcount
-                releasehash
-                txstatus
-                amount
-                creator
-                originaddress
-                originchain
-                originsymbol
-                targetsymbol
-                targetaddress
-                targetchain
-                tx_id
-                kimahash
-              }
-            }`,
-          variables: {
-            txId: BigInt(txId)
+      const response = await fetchWrapper.get<ApiTxStatusResponse>(
+        `${process.env.KIMA_BACKEND_NODE_PROVIDER_QUERY}/kima-finance/kima-blockchain/transaction/transaction_data/${txId}`
+      )
+      if (typeof response === 'string') {
+        const message = `failed to get status for transaction ${txId}`
+        console.error(message, response)
+        res.status(500).json({ message })
+        return
+      }
+
+      // convert to GraphQL response for backwards compatibility
+      const data = response.transactionData
+      const output = {
+        data: {
+          transaction_data: {
+            failreason: data.failReason,
+            pullfailcount: Number(data.pullFailCount),
+            pullhash: data.tssPullHash,
+            releasefailcount: Number(data.releaseFailCount),
+            releasehash: data.tssReleaseHash,
+            txstatus: data.status,
+            amount: Number(data.amount),
+            creator: data.creator,
+            originaddress: data.originAddress,
+            originchain: data.originChain,
+            originsymbol: data.originSymbol,
+            targetsymbol: data.targetSymbol,
+            targetaddress: data.targetAddress,
+            targetchain: data.targetChain,
+            tx_id: data.index,
+            kimahash: data.kimaTxHash
           }
         }
-      )
-      res.status(200).send(result)
+      } satisfies GraphqlTxStatusResponse
+
+      res.status(200).json(output)
     } catch (e) {
       console.error(e)
       res.status(500).send(`failed to get status for transaction ${txId}`)

--- a/src/types/transaction-status.ts
+++ b/src/types/transaction-status.ts
@@ -1,22 +1,99 @@
 export interface TransactionStatus {
+  failreason: string
+  pullfailcount: number
+  pullhash: string
+  releasefailcount: number
+  releasehash: string
+  txstatus: string
+  amount: number
+  creator: string
+  originaddress: string
+  originchain: string
+  originsymbol: string
+  targetsymbol: string
+  targetaddress: string
+  targetchain: string
+  tx_id: string
+  kimahash: string
+}
+
+export interface GraphqlTxStatusResponse {
   data: {
-    transaction_status: {
-      failreason: string
-      pullfailcount: number
-      pullhash: string
-      releasefailcount: number
-      releasehash: string
-      txstatus: string
-      amount: number
-      creator: string
-      originaddress: string
-      originchain: string
-      originsymbol: string
-      targetsymbol: string
-      targetaddress: string
-      targetchain: string
-      tx_id: string
-      kimahash: string
-    }
+    transaction_data: TransactionStatus
+  }
+}
+
+export interface GraphqlLiquidityTxStatusResponse {
+  data: {
+    liquidity_transaction_data: TransactionStatus
+  }
+}
+
+export interface ApiLiquidityTxStatusResponse {
+  LiquidityTransactionData: {
+    index: string
+    chain: string
+    providerChainAddress: string
+    providerKimaAddress: string
+    symbol: string
+    poolAddr: string
+    amount: string
+    options: string
+    time: string
+    status: string
+    confirmedBlockHash: string
+    signedKey: string
+    tssPullHash: string
+    tssReleaseHash: string
+    kimaTxHash: string
+    failReason: string
+    pullFailCount: string
+    releaseFailCount: string
+    creator: string
+    processing: boolean
+    tssMsgId: string
+    timestamp: string
+    handleId: string
+    txType: string
+    htlcExpirationTimestamp: string
+    htlcCreationHash: string
+    htlcCreationVout: number
+    htlcVersion: string
+    senderPubKey: string | null
+  }
+}
+
+export interface ApiTxStatusResponse {
+  transactionData: {
+    index: string
+    originChain: string
+    originAddress: string
+    targetChain: string
+    targetAddress: string
+    originSymbol: string
+    targetSymbol: string
+    amount: string
+    time: string
+    status: string
+    confirmedBlockHash: string
+    signedKey: string
+    fee: string
+    tssPullHash: string
+    tssReleaseHash: string
+    kimaTxHash: string
+    failReason: string
+    pullFailCount: string
+    releaseFailCount: string
+    creator: string
+    processing: boolean
+    tssMsgId: string
+    timestamp: string
+    handleId: string
+    htlcExpirationTimestamp: string
+    htlcCreationHash: string
+    htlcCreationVout: number
+    htlcVersion: string
+    senderPubKey: string | null
+    options: string
   }
 }


### PR DESCRIPTION
- the graphql interface relies on indexing which currently has unreliable performance. @gilkima advised switching to the API call
- Removes ENV var `KIMA_BACKEND_NODE_PROVIDER_GRAPHQL`

⚠️ Will need to remove this env var from the validation in `/src/env-validate.ts` after merging the ENV validation PR.