### PR TITLE
fix: Solana RPC url should be devent not testnet

### DIFF
--- a/src/data/chains.ts
+++ b/src/data/chains.ts
@@ -352,7 +352,7 @@ export const CHAINS: Chain[] = [
       }
     ],
     rpcUrls: {
-      default: { http: ['https://api.testnet.solana.com'] }
+      default: { http: ['https://api.devnet.solana.com'] }
     },
     faucets: [],
     nativeCurrency: {


### PR DESCRIPTION
The widget uses Solana devnet not testnet