### PR TITLE
bugfix: use start instead of dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ WORKDIR /usr/src/app
 RUN npm install
 RUN rm -f .npmrc
 EXPOSE 3000
-CMD npm run dev
+CMD npm run start


### PR DESCRIPTION
npm run dev target broken as it does not use build subdirectory