### PR TITLE
Feat/chain location

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
       "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
-        "@kimafinance/kima-transaction-api": "^1.3.2",
+        "@cosmjs/crypto": "^0.33.1",
+        "@cosmjs/encoding": "^0.33.1",
+        "@cosmjs/proto-signing": "^0.33.1",
+        "@kimafinance/kima-transaction-api": "^1.3.3",
         "@solana/web3.js": "^1.95.5",
         "@types/morgan": "^1.9.9",
         "@types/swagger-jsdoc": "^6.0.4",
@@ -27,7 +30,7 @@
         "swagger-ui-express": "^5.0.1",
         "tron-format-address": "^0.1.12",
         "uuid": "^9.0.1",
-        "viem": "^2.23.5",
+        "viem": "^2.29.1",
         "zod": "^3.24.2"
       },
       "devDependencies": {
@@ -1536,9 +1539,9 @@
       "license": "MIT"
     },
     "node_modules/@kimafinance/kima-transaction-api": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@kimafinance/kima-transaction-api/-/kima-transaction-api-1.3.2.tgz",
-      "integrity": "sha512-kdmcBMGtKGA9t81OR0e9tIyTIzy0MoHUn3Ns8/FGYTi8Z8Vp7Tqu6yVbQJpNLNIxlHA4Qe4XPJJER4AlgpVjvA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@kimafinance/kima-transaction-api/-/kima-transaction-api-1.3.3.tgz",
+      "integrity": "sha512-Ito0BIZnBB3r6vKPmnIHiC3TaYsT8u6cJJsgC4+WYa8xJFn7inabXKIdPOyQrypfr4LC22ncxtnuV6xVj+tcSg==",
       "license": "MIT",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.31.1",
@@ -1592,12 +1595,12 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.2.tgz",
+      "integrity": "sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.7.1"
+        "@noble/hashes": "1.7.2"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1607,9 +1610,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.2.tgz",
+      "integrity": "sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1690,9 +1693,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@scure/base": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
-      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.5.tgz",
+      "integrity": "sha512-9rE6EOVeIQzt5TSu4v+K523F8u6DhBsoZWPGKlnCshhlDhy0kJzUX4V+tr2dWmzF1GdekvThABoEQBGBQI7xZw==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -5927,9 +5930,9 @@
       "peer": true
     },
     "node_modules/ox": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.7.tgz",
-      "integrity": "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==",
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.9.tgz",
+      "integrity": "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==",
       "funding": [
         {
           "type": "github",
@@ -7506,9 +7509,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.23.5",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.23.5.tgz",
-      "integrity": "sha512-cUfBHdFQHmBlPW0loFXda0uZcoU+uJw3NRYQRwYgkrpH6PgovH8iuVqDn6t1jZk82zny4wQL54c9dCX2W9kLMg==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.29.1.tgz",
+      "integrity": "sha512-mhLn0vDdsxZ4taB7XYgnIVNvXASm60KyPAkvw4k8uNCQ+HLH+5jUgKvLg4AP3y6VJxsgiVPwqUt0dJANDF5DZA==",
       "funding": [
         {
           "type": "github",
@@ -7517,14 +7520,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "1.8.1",
-        "@noble/hashes": "1.7.1",
+        "@noble/curves": "1.8.2",
+        "@noble/hashes": "1.7.2",
         "@scure/bip32": "1.6.2",
         "@scure/bip39": "1.5.4",
         "abitype": "1.0.8",
         "isows": "1.0.6",
-        "ox": "0.6.7",
-        "ws": "8.18.0"
+        "ox": "0.6.9",
+        "ws": "8.18.1"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -7536,9 +7539,9 @@
       }
     },
     "node_modules/viem/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@cosmjs/crypto": "^0.33.1",
     "@cosmjs/encoding": "^0.33.1",
     "@cosmjs/proto-signing": "^0.33.1",
-    "@kimafinance/kima-transaction-api": "^1.3.2",
+    "@kimafinance/kima-transaction-api": "^1.3.3",
     "@solana/web3.js": "^1.95.5",
     "@types/morgan": "^1.9.9",
     "@types/swagger-jsdoc": "^6.0.4",
@@ -57,7 +57,7 @@
     "swagger-ui-express": "^5.0.1",
     "tron-format-address": "^0.1.12",
     "uuid": "^9.0.1",
-    "viem": "^2.23.5",
+    "viem": "^2.29.1",
     "zod": "^3.24.2"
   }
 }

--- a/src/data/chains.ts
+++ b/src/data/chains.ts
@@ -24,6 +24,7 @@ export const CHAINS: Chain[] = [
     ...arbitrum,
     compatibility: ChainCompatibility.EVM,
     shortName: 'ARB',
+    supportedLocations: ['origin', 'target'],
     supportedTokens: [
       {
         symbol: 'USDT',
@@ -41,6 +42,7 @@ export const CHAINS: Chain[] = [
     ...arbitrumSepolia,
     compatibility: ChainCompatibility.EVM,
     shortName: 'ARB',
+    supportedLocations: ['origin', 'target'],
     supportedTokens: [
       {
         symbol: 'USDK',
@@ -53,6 +55,7 @@ export const CHAINS: Chain[] = [
     ...avalanche,
     compatibility: ChainCompatibility.EVM,
     shortName: 'AVX',
+    supportedLocations: ['origin', 'target'],
     supportedTokens: [
       {
         symbol: 'USDT',
@@ -70,6 +73,7 @@ export const CHAINS: Chain[] = [
     ...avalancheFuji,
     compatibility: ChainCompatibility.EVM,
     shortName: 'AVX',
+    supportedLocations: ['origin', 'target'],
     supportedTokens: [
       {
         symbol: 'USDK',
@@ -83,6 +87,7 @@ export const CHAINS: Chain[] = [
   //   ...base,
   //   compatibility: ChainCompatibility.EVM,
   //   shortName: 'BASE',
+  //   supportedLocations: ['origin', 'target'],
   //   supportedTokens: [
   //     {
   //       symbol: 'USDC',
@@ -95,6 +100,7 @@ export const CHAINS: Chain[] = [
     ...baseSepolia,
     compatibility: ChainCompatibility.EVM,
     shortName: 'BASE',
+    supportedLocations: ['origin', 'target'],
     supportedTokens: [
       {
         symbol: 'KIMAUSD',
@@ -107,6 +113,7 @@ export const CHAINS: Chain[] = [
     ...berachain,
     shortName: 'BERA',
     compatibility: ChainCompatibility.EVM,
+    supportedLocations: ['origin'],
     supportedTokens: [
       {
         symbol: 'HONEY',
@@ -119,6 +126,7 @@ export const CHAINS: Chain[] = [
     ...berachainTestnetbArtio,
     shortName: 'BERA',
     compatibility: ChainCompatibility.EVM,
+    supportedLocations: ['origin'],
     supportedTokens: [
       {
         symbol: 'USDK',
@@ -131,6 +139,7 @@ export const CHAINS: Chain[] = [
     ...bsc,
     compatibility: ChainCompatibility.EVM,
     shortName: 'BSC',
+    supportedLocations: ['origin', 'target'],
     supportedTokens: [
       {
         symbol: 'USDT',
@@ -148,6 +157,7 @@ export const CHAINS: Chain[] = [
     ...bscTestnet,
     compatibility: ChainCompatibility.EVM,
     shortName: 'BSC',
+    supportedLocations: ['origin', 'target'],
     supportedTokens: [
       {
         symbol: 'USDK',
@@ -161,6 +171,7 @@ export const CHAINS: Chain[] = [
   //   id: 0,
   //   shortName: 'BTC',
   //   name: 'Bitcoin',
+  //   supportedLocations: ['origin', 'target'],
   //   supportedTokens: [],
   //   compatibility: ChainCompatibility.BTC,
   //   rpcUrls: {
@@ -191,6 +202,7 @@ export const CHAINS: Chain[] = [
   //     }
   //   ],
   //   compatibility: ChainCompatibility.BTC,
+  //   supportedLocations: ['origin', 'target'],
   //   rpcUrls: {
   //     default: { http: [] }
   //   },
@@ -212,6 +224,7 @@ export const CHAINS: Chain[] = [
     ...mainnet,
     shortName: 'ETH',
     compatibility: ChainCompatibility.EVM,
+    supportedLocations: ['origin', 'target'],
     supportedTokens: [
       {
         symbol: 'USDT',
@@ -230,6 +243,7 @@ export const CHAINS: Chain[] = [
     name: 'Ethereum Sepolia',
     shortName: 'ETH',
     compatibility: ChainCompatibility.EVM,
+    supportedLocations: ['origin', 'target'],
     supportedTokens: [
       {
         symbol: 'USDK',
@@ -247,6 +261,7 @@ export const CHAINS: Chain[] = [
     ...optimism,
     shortName: 'OPT',
     compatibility: ChainCompatibility.EVM,
+    supportedLocations: ['origin', 'target'],
     supportedTokens: [
       {
         symbol: 'USDT',
@@ -264,6 +279,7 @@ export const CHAINS: Chain[] = [
     ...optimismSepolia,
     shortName: 'OPT',
     compatibility: ChainCompatibility.EVM,
+    supportedLocations: ['origin', 'target'],
     supportedTokens: [
       {
         symbol: 'USDK',
@@ -276,6 +292,7 @@ export const CHAINS: Chain[] = [
     ...polygon,
     shortName: 'POL',
     compatibility: ChainCompatibility.EVM,
+    supportedLocations: ['origin', 'target'],
     supportedTokens: [
       {
         symbol: 'USDT',
@@ -293,6 +310,7 @@ export const CHAINS: Chain[] = [
     ...polygonAmoy,
     shortName: 'POL',
     compatibility: ChainCompatibility.EVM,
+    supportedLocations: ['origin', 'target'],
     supportedTokens: [
       {
         symbol: 'USDK',
@@ -311,6 +329,7 @@ export const CHAINS: Chain[] = [
     name: 'Solana',
     shortName: 'SOL',
     compatibility: ChainCompatibility.SELF,
+    supportedLocations: ['origin', 'target'],
     supportedTokens: [
       {
         symbol: 'USDT',
@@ -344,6 +363,7 @@ export const CHAINS: Chain[] = [
     name: 'Solana Devnet',
     shortName: 'SOL',
     compatibility: ChainCompatibility.SELF,
+    supportedLocations: ['origin', 'target'],
     supportedTokens: [
       {
         symbol: 'USDK',
@@ -372,6 +392,7 @@ export const CHAINS: Chain[] = [
     ...tron,
     shortName: 'TRX',
     compatibility: ChainCompatibility.SELF,
+    supportedLocations: ['origin', 'target'],
     supportedTokens: [
       {
         symbol: 'USDT',
@@ -385,6 +406,7 @@ export const CHAINS: Chain[] = [
     name: 'Tron Nile',
     shortName: 'TRX',
     compatibility: ChainCompatibility.SELF,
+    supportedLocations: ['origin', 'target'],
     supportedTokens: [
       {
         symbol: 'USDK',
@@ -412,6 +434,7 @@ export const CHAINS: Chain[] = [
     name: 'Credit Card',
     shortName: 'CC',
     compatibility: ChainCompatibility.CC,
+    supportedLocations: ['origin'],
     supportedTokens: [
       {
         symbol: 'USD',
@@ -441,6 +464,7 @@ export const CHAINS: Chain[] = [
     name: 'Credit Card',
     shortName: 'CC',
     compatibility: ChainCompatibility.CC,
+    supportedLocations: ['origin'],
     supportedTokens: [
       {
         symbol: 'USD',
@@ -470,6 +494,7 @@ export const CHAINS: Chain[] = [
   //   name: 'Tron Shasta',
   //   shortName: 'TRX',
   //   compatibility: ChainCompatibility.EVM,
+  //   supportedLocations: ['origin', 'target'],
   //   supportedTokens: [],
   //   nativeCurrency: {
   //     name: 'TRON',

--- a/src/data/chains.ts
+++ b/src/data/chains.ts
@@ -3,6 +3,7 @@ import {
   arbitrumSepolia,
   avalanche,
   avalancheFuji,
+  base,
   // base,
   baseSepolia,
   berachain,
@@ -83,19 +84,19 @@ export const CHAINS: Chain[] = [
     ]
   },
   // TODO: enable once BASE supported in mainnet
-  // {
-  //   ...base,
-  //   compatibility: ChainCompatibility.EVM,
-  //   shortName: 'BASE',
-  //   supportedLocations: ['origin', 'target'],
-  //   supportedTokens: [
-  //     {
-  //       symbol: 'USDC',
-  //       address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-  //       decimals: 6
-  //     }
-  //   ]
-  // },
+  {
+    ...base,
+    compatibility: ChainCompatibility.EVM,
+    shortName: 'BASE',
+    supportedLocations: ['origin', 'target'],
+    supportedTokens: [
+      {
+        symbol: 'USDC',
+        address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+        decimals: 6
+      }
+    ]
+  },
   {
     ...baseSepolia,
     compatibility: ChainCompatibility.EVM,

--- a/src/service/chain-fiter.ts
+++ b/src/service/chain-fiter.ts
@@ -1,5 +1,9 @@
-import { ChainFilterConfig, ChainFilterMode } from '../types/chain'
-import { ChainEnv } from '../types/chain-env'
+import {
+  Chain,
+  ChainFilterConfig,
+  ChainFilterMode,
+  ChainLocation
+} from '../types/chain'
 import { ChainName } from '../types/chain-name'
 
 export class ChainFilter {
@@ -7,17 +11,22 @@ export class ChainFilter {
   readonly mode: ChainFilterMode
 
   constructor(
-    private readonly env: ChainEnv,
-    private readonly allChainsSet: Set<ChainName>,
-    chainFilter: ChainFilterConfig
+    private readonly allChainsMap: Map<ChainName, Chain>,
+    private readonly location: ChainLocation,
+    chainFilter?: ChainFilterConfig
   ) {
-    this.filterSet = new Set(chainFilter.chains)
-    this.mode = chainFilter.mode
+    this.filterSet = chainFilter ? new Set(chainFilter.chains) : new Set()
+    this.mode = chainFilter?.mode ?? 'blacklist'
   }
 
   isSupportedChain = (chainShortName: string): boolean => {
-    const isAvailable = this.allChainsSet.has(chainShortName as ChainName)
-    if (!isAvailable) return false
+    const chain = this.allChainsMap.get(chainShortName as ChainName)
+    if (!chain) return false
+
+    const supportedLocation = chain.supportedLocations.includes(
+      this.location as ChainLocation
+    )
+    if (!supportedLocation) return false
 
     return this.mode === 'whitelist'
       ? this.filterSet.has(chainShortName as ChainName)

--- a/src/test/chains.test.ts
+++ b/src/test/chains.test.ts
@@ -1,15 +1,13 @@
+import { CHAINS } from '../data/chains'
 import { ChainsService } from '../service/chains.service'
 import { ChainList, ChainLocation, FilterConfig } from '../types/chain'
 import { ChainEnv } from '../types/chain-env'
-import { ChainName } from '../types/chain-name'
 
 jest.mock('../fetch-wrapper')
 
 describe('Chain Service', () => {
   let chainFilter: FilterConfig
   let service: ChainsService
-  const chains = Object.values(ChainName)
-  const numChains = chains.length
   let chainEnv: ChainEnv
 
   beforeEach(() => {
@@ -39,10 +37,23 @@ describe('Chain Service', () => {
           service = new ChainsService(chainEnv, undefined)
         })
 
-        it.each(chains.map((chain) => ({ chain, expected: true })))(
-          'should return true for all chains: case $chain',
-          ({ chain, expected }) => {
-            const result = service.isSupportedChain(chain, 'origin')
+        it.each(
+          CHAINS.flatMap((chain) =>
+            ['origin', 'target'].map((location) => ({
+              chain: chain.shortName,
+              location,
+              expected: chain.supportedLocations.includes(
+                location as ChainLocation
+              )
+            }))
+          )
+        )(
+          'should return the chain value: case $chain $location $expected',
+          ({ chain, location, expected }) => {
+            const result = service.isSupportedChain(
+              chain,
+              location as ChainLocation
+            )
             expect(result).toEqual(expected)
           }
         )
@@ -56,36 +67,149 @@ describe('Chain Service', () => {
 
         it.each([
           // whitelist from origin
-          { case: 'whitelist', chain: 'ARB', location: 'origin', expected: true },
-          { case: 'whitelist', chain: 'AVX', location: 'origin', expected: false },
-          { case: 'whitelist', chain: 'BASE', location: 'origin', expected: false },
-          { case: 'whitelist', chain: 'BERA', location: 'origin', expected: false },
-          { case: 'whitelist', chain: 'BSC', location: 'origin', expected: false },
-          { case: 'whitelist', chain: 'ETH', location: 'origin', expected: false },
-          { case: 'whitelist', chain: 'OPT', location: 'origin', expected: true },
-          { case: 'whitelist', chain: 'POL', location: 'origin', expected: false },
-          { case: 'whitelist', chain: 'SOL', location: 'origin', expected: false },
-          { case: 'whitelist', chain: 'TRX', location: 'origin', expected: false },
+          {
+            case: 'whitelist',
+            chain: 'ARB',
+            location: 'origin',
+            expected: true
+          },
+          {
+            case: 'whitelist',
+            chain: 'AVX',
+            location: 'origin',
+            expected: false
+          },
+          {
+            case: 'whitelist',
+            chain: 'BASE',
+            location: 'origin',
+            expected: false
+          },
+          {
+            case: 'whitelist',
+            chain: 'BERA',
+            location: 'origin',
+            expected: false
+          },
+          {
+            case: 'whitelist',
+            chain: 'BSC',
+            location: 'origin',
+            expected: false
+          },
+          {
+            case: 'whitelist',
+            chain: 'ETH',
+            location: 'origin',
+            expected: false
+          },
+          {
+            case: 'whitelist',
+            chain: 'OPT',
+            location: 'origin',
+            expected: true
+          },
+          {
+            case: 'whitelist',
+            chain: 'POL',
+            location: 'origin',
+            expected: false
+          },
+          {
+            case: 'whitelist',
+            chain: 'SOL',
+            location: 'origin',
+            expected: false
+          },
+          {
+            case: 'whitelist',
+            chain: 'TRX',
+            location: 'origin',
+            expected: false
+          },
 
           // blacklist from target
-          { case: 'blacklist', chain: 'ARB', location: 'target', expected: true },
-          { case: 'blacklist', chain: 'AVX', location: 'target', expected: true },
-          { case: 'blacklist', chain: 'BASE', location: 'target', expected: true },
-          { case: 'blacklist', chain: 'BERA', location: 'target', expected: true },
-          { case: 'blacklist', chain: 'BSC', location: 'target', expected: false },
-          { case: 'blacklist', chain: 'ETH', location: 'target', expected: true },
-          { case: 'blacklist', chain: 'OPT', location: 'target', expected: true },
-          { case: 'blacklist', chain: 'POL', location: 'target', expected: true },
-          { case: 'blacklist', chain: 'SOL', location: 'target', expected: true },
-          { case: 'blacklist', chain: 'TRX', location: 'target', expected: false },
+          {
+            case: 'blacklist',
+            chain: 'ARB',
+            location: 'target',
+            expected: true
+          },
+          {
+            case: 'blacklist',
+            chain: 'AVX',
+            location: 'target',
+            expected: true
+          },
+          {
+            case: 'blacklist',
+            chain: 'BASE',
+            location: 'target',
+            expected: true
+          },
+          {
+            case: 'blacklist',
+            chain: 'BERA',
+            location: 'target',
+            expected: false
+          },
+          {
+            case: 'blacklist',
+            chain: 'BSC',
+            location: 'target',
+            expected: false
+          },
+          {
+            case: 'blacklist',
+            chain: 'ETH',
+            location: 'target',
+            expected: true
+          },
+          {
+            case: 'blacklist',
+            chain: 'OPT',
+            location: 'target',
+            expected: true
+          },
+          {
+            case: 'blacklist',
+            chain: 'POL',
+            location: 'target',
+            expected: true
+          },
+          {
+            case: 'blacklist',
+            chain: 'SOL',
+            location: 'target',
+            expected: true
+          },
+          {
+            case: 'blacklist',
+            chain: 'TRX',
+            location: 'target',
+            expected: false
+          },
 
           // invalid chain shortname
-          { case: 'invalid', chain: 'INVALID', location: 'origin', expected: false },
-          { case: 'invalid', chain: 'INVALID', location: 'target', expected: false }
+          {
+            case: 'invalid',
+            chain: 'INVALID',
+            location: 'origin',
+            expected: false
+          },
+          {
+            case: 'invalid',
+            chain: 'INVALID',
+            location: 'target',
+            expected: false
+          }
         ])(
           'case: $case $location filter should return $expected for $chain',
           ({ chain, location, expected }) => {
-            const result = service.isSupportedChain(chain, location as ChainLocation )
+            const result = service.isSupportedChain(
+              chain,
+              location as ChainLocation
+            )
             expect(result).toEqual(expected)
           }
         )

--- a/src/types/chain-name.ts
+++ b/src/types/chain-name.ts
@@ -6,12 +6,11 @@ export enum ChainName {
   BERA = 'BERA',
   BSC = 'BSC',
   // BTC = 'BTC',
+  CREDITCARD = 'CC',
   ETHEREUM = 'ETH',
-  // FIAT = 'FIAT',
+  FIAT = 'FIAT',
   OPTIMISM = 'OPT',
   POLYGON = 'POL',
   SOLANA = 'SOL',
-  TRON = 'TRX',
-  CREDITCARD = 'CC',
-  FIAT = 'FIAT'
+  TRON = 'TRX'
 }

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -16,12 +16,9 @@ export interface Chain extends ViemChain {
   shortName: string
   compatibility: ChainCompatibility
   faucets?: string[]
+  supportedLocations: ChainLocation[]
   supportedTokens: TokenDto[]
   disabled?: boolean
-}
-
-export interface SupportedChain extends Chain {
-  supportedLocations: ChainLocation[]
 }
 
 const filterMode = z.enum(['whitelist', 'blacklist'])


### PR DESCRIPTION
* Adds prop `chainLocations` to the chain data returned by `GET /chains`
* Fix: BERA and CC chains should now show only in the origin network on the frontend
* Fix: when submitting BERA and CC chains should now be reject with 400 status when in the target chain
* Updates `kima-transaction-api` to version `1.3.3`
* Updates Viem to latest version

⚠️  Corresponding frontend PR: https://github.com/kima-finance/kima-transaction-widget/pull/173