### PR TITLE
Feat: return partner id from /chain/env

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -39,6 +39,8 @@ NODE_ENV=production
 # Port to run the server on
 PORT=3001
 
+# Required for credit card transactions only
+PAYMENT_PARTNER_ID=Kima
 
 ################################################################################
 # Testnet
@@ -80,3 +82,6 @@ NODE_ENV=development
 
 # Port to run the server on
 PORT=3001
+
+# Required for credit card transactions only
+PAYMENT_PARTNER_ID=KimaTest

--- a/src/env-validate.ts
+++ b/src/env-validate.ts
@@ -70,7 +70,10 @@ const envSchema = z.object({
     .optional(),
 
   // Port the server will listen on
-  PORT: z.coerce.number().default(3000)
+  PORT: z.coerce.number().default(3000),
+
+  // Required for credit card transactions only
+  PAYMENT_PARTNER_ID: z.string().optional()
 })
 
 export type Environment = z.infer<typeof envSchema>

--- a/src/routes/chains.ts
+++ b/src/routes/chains.ts
@@ -102,7 +102,8 @@ chainsRouter.get('/chain', async (_, res: Response) => {
 chainsRouter.get('/env', async (_, res: Response) => {
   return res.json({
     env: ENV.KIMA_ENVIRONMENT as ChainEnv,
-    kimaExplorer: ENV.KIMA_EXPLORER as string
+    kimaExplorer: ENV.KIMA_EXPLORER as string,
+    paymentPartnerId: ENV.PAYMENT_PARTNER_ID as string
   })
 })
 


### PR DESCRIPTION
Feat: return partner id from /chain/env
* Adds new optional ENV var `PAYMENT_PARTNER_ID` that's required when using the credit card feature

Corresponding Widget PR: https://github.com/kima-finance/kima-transaction-widget/pull/176