### PR TITLE
feat: merge static and Kima API chain data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kima-transaction-backend",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kima-transaction-backend",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@cosmjs/crypto": "^0.33.1",
@@ -32,6 +32,8 @@
         "js-sha3": "^0.9.3",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
+        "node-cache": "^5.1.2",
+        "safe-stable-stringify": "^2.5.0",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
         "tron-format-address": "^0.1.12",
@@ -4122,6 +4124,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -7133,6 +7144,18 @@
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
       "license": "MIT"
     },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -8088,6 +8111,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "js-sha3": "^0.9.3",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
+    "node-cache": "^5.1.2",
+    "safe-stable-stringify": "^2.5.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "tron-format-address": "^0.1.12",

--- a/src/data/chains.ts
+++ b/src/data/chains.ts
@@ -1,3 +1,7 @@
+// import * as chains from 'viem/chains'
+// import { Chain as ViemChain } from 'viem'
+import { Chain, ChainCompatibility } from '../types/chain'
+
 import {
   arbitrum,
   arbitrumSepolia,
@@ -17,7 +21,18 @@ import {
   sepolia,
   tron
 } from 'viem/chains'
-import { Chain, ChainCompatibility } from '../types/chain'
+
+// const allViemChains: Record<number, ViemChain> = Object.values(chains)
+//   .filter((c) => typeof c === 'object' && 'id' in c && 'rpcUrls' in c)
+//   .reduce((acc, chain) => {
+//     acc[chain.id] = chain as ViemChain
+//     return acc
+//   }, {} as Record<number, ViemChain>)
+
+// this won't work for chains returned from the Kima API as they don't chain chainId
+// export const getChainById = (id: number): ViemChain | undefined => {
+//   return allViemChains[id]
+// }
 
 export const CHAINS: Chain[] = [
   {
@@ -30,7 +45,8 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USD',
         decimals: 2,
-        address: ''
+        address: '',
+        peggedTo: 'USD'
       }
     ],
     nativeCurrency: {
@@ -60,7 +76,8 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USD',
         decimals: 2,
-        address: ''
+        address: '',
+        peggedTo: 'USD'
       }
     ],
     nativeCurrency: {
@@ -88,12 +105,14 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USDT',
         address: '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9',
-        decimals: 6
+        decimals: 6,
+        peggedTo: 'USD'
       },
       {
         symbol: 'USDC',
         address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
-        decimals: 6
+        decimals: 6,
+        peggedTo: 'USD'
       }
     ]
   },
@@ -106,7 +125,8 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USDK',
         address: '0x2cf79df2879902a2fc06329b1760e0f2ad9a3a47',
-        decimals: 18
+        decimals: 18,
+        peggedTo: 'USD'
       }
     ]
   },
@@ -119,12 +139,14 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USDT',
         address: '0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7',
-        decimals: 6
+        decimals: 6,
+        peggedTo: 'USD'
       },
       {
         symbol: 'USDC',
         address: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
-        decimals: 6
+        decimals: 6,
+        peggedTo: 'USD'
       }
     ]
   },
@@ -137,7 +159,8 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USDK',
         address: '0x5d8598Ce65f15f14c58aD3a4CD285223c8e76a2E',
-        decimals: 18
+        decimals: 18,
+        peggedTo: 'USD'
       }
     ]
   },
@@ -151,7 +174,8 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USDC',
         address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-        decimals: 6
+        decimals: 6,
+        peggedTo: 'USD'
       }
     ]
   },
@@ -164,7 +188,8 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USDK',
         address: '0x2B0F2060d358a2DF51dBc4147a09445b11EF5D41',
-        decimals: 18
+        decimals: 18,
+        peggedTo: 'USD'
       }
     ]
   },
@@ -177,7 +202,8 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'HONEY',
         address: '0xFCBD14DC51f0A4d49d5E53C2E0950e0bC26d0Dce',
-        decimals: 18
+        decimals: 18,
+        peggedTo: 'USD'
       }
     ]
   },
@@ -190,7 +216,8 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USDK',
         address: '0xe5dB851969B4d8EE8A023F4b991CbED6e39dca80',
-        decimals: 18
+        decimals: 18,
+        peggedTo: 'USD'
       }
     ]
   },
@@ -203,12 +230,14 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USDT',
         address: '0x55d398326f99059fF775485246999027B3197955',
-        decimals: 6
+        decimals: 6,
+        peggedTo: 'USD'
       },
       {
         symbol: 'USDC',
         address: '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d',
-        decimals: 6
+        decimals: 6,
+        peggedTo: 'USD'
       }
     ]
   },
@@ -221,7 +250,8 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USDK',
         address: '0x3eb36be2c3FD244139756F681420637a2a9464e3',
-        decimals: 18
+        decimals: 18,
+        peggedTo: 'USD'
       }
     ],
     faucets: ['https://testnet.bnbchain.org/faucet-smart']
@@ -288,12 +318,14 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USDT',
         address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
-        decimals: 6
+        decimals: 6,
+        peggedTo: 'USD'
       },
       {
         symbol: 'USDC',
         address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-        decimals: 6
+        decimals: 6,
+        peggedTo: 'USD'
       }
     ]
   },
@@ -307,7 +339,8 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USDK',
         address: '0x5FF59Bf2277A1e6bA9bB8A38Ea3F9ABfd3d9345a',
-        decimals: 18
+        decimals: 18,
+        peggedTo: 'USD'
       }
       // {
       //   symbol: 'WBTC',
@@ -325,12 +358,14 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USDT',
         address: '0x94b008aa00579c1307b0ef2c499ad98a8ce58e58',
-        decimals: 6
+        decimals: 6,
+        peggedTo: 'USD'
       },
       {
         symbol: 'USDC',
         address: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
-        decimals: 6
+        decimals: 6,
+        peggedTo: 'USD'
       }
     ]
   },
@@ -343,7 +378,8 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USDK',
         address: '0x2cf79df2879902a2fc06329b1760e0f2ad9a3a47',
-        decimals: 18
+        decimals: 18,
+        peggedTo: 'USD'
       }
     ]
   },
@@ -356,12 +392,14 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USDT',
         address: '0xc2132d05d31c914a87c6611c10748aeb04b58e8f',
-        decimals: 6
+        decimals: 6,
+        peggedTo: 'USD'
       },
       {
         symbol: 'USDC',
         address: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
-        decimals: 6
+        decimals: 6,
+        peggedTo: 'USD'
       }
     ]
   },
@@ -374,7 +412,8 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USDK',
         address: '0x30171cfb10ed578814a22475a190306776bc8392',
-        decimals: 18
+        decimals: 18,
+        peggedTo: 'USD'
       }
       // {
       //   symbol: 'WBTC',
@@ -393,12 +432,14 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USDT',
         address: 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
-        decimals: 6
+        decimals: 6,
+        peggedTo: 'USD'
       },
       {
         symbol: 'USDC',
         address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-        decimals: 6
+        decimals: 6,
+        peggedTo: 'USD'
       }
     ],
     rpcUrls: {
@@ -427,7 +468,8 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USDK',
         address: '9YSFWfU9Ram6mAo2QP9zsTnA8yFkkkFGEs3kGgjtQKvp',
-        decimals: 6
+        decimals: 6,
+        peggedTo: 'USD'
       }
     ],
     rpcUrls: {
@@ -463,7 +505,8 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USDT',
         address: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
-        decimals: 6
+        decimals: 6,
+        peggedTo: 'USD'
       }
     ]
   },
@@ -477,7 +520,8 @@ export const CHAINS: Chain[] = [
       {
         symbol: 'USDK',
         address: 'TEuRmCALTUY2syY1EE6mMYnyfmNfFfMpYz',
-        decimals: 18
+        decimals: 18,
+        peggedTo: 'USD'
       }
     ],
     nativeCurrency: {

--- a/src/routes/chains.ts
+++ b/src/routes/chains.ts
@@ -603,7 +603,7 @@ chainsRouter.get(
     //   .optional()
   ],
   async (req: Request, res: Response) => {
-    const chains = chainsService.supportedChains()
+    const chains = await chainsService.supportedChains()
     res.status(200).json(chains)
   }
 )

--- a/src/service/chain-fiter.ts
+++ b/src/service/chain-fiter.ts
@@ -7,11 +7,11 @@ import {
 import { ChainName } from '../types/chain-name'
 
 export class ChainFilter {
-  private readonly filterSet: Set<ChainName>
+  private filterSet: Set<ChainName>
   readonly mode: ChainFilterMode
 
   constructor(
-    private readonly allChainsMap: Map<ChainName, Chain>,
+    public allChainsMap: Map<ChainName, Chain>,
     private readonly location: ChainLocation,
     chainFilter?: ChainFilterConfig
   ) {

--- a/src/types/chain.dto..ts
+++ b/src/types/chain.dto..ts
@@ -1,10 +1,13 @@
-import { TokenDto } from './token.dto'
+import { KimaApiTokenDto, TokenDto } from './token.dto'
 
 export interface ChainDto {
   id: string
   name: string
   symbol: string
-  tokens: TokenDto[]
+  tokens: KimaApiTokenDto[]
   disabled: boolean
   isEvm: boolean
+  derivationAlgorithm: DerivationAlgorithm
 }
+
+export type DerivationAlgorithm = 'ECDSA' | 'EDDSA'

--- a/src/types/token.dto.ts
+++ b/src/types/token.dto.ts
@@ -1,5 +1,10 @@
-export interface TokenDto {
+export interface KimaApiTokenDto {
   symbol: string
   address: string
+  decimals: string
+  peggedTo: string // currency symbol i.e. USD, EUR
+}
+
+export interface TokenDto extends Omit<KimaApiTokenDto, 'decimals'> {
   decimals: number
 }

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,47 @@
+import NodeCache from 'node-cache';
+import stringify from 'safe-stable-stringify';
+
+// Type for any async function
+type AnyAsyncFn<TArgs extends any[], TResult> = (...args: TArgs) => Promise<TResult>;
+
+// Cache and pending maps
+const cache = new NodeCache();
+const pending: Record<string, Promise<any>> = {};
+
+/**
+ * Wraps an async function with TTL cache and deduplication.
+ *
+ * @param keyBase   - Unique key for this function (string)
+ * @param fn        - Your async function
+ * @param ttl       - Cache time in seconds (default: 600)
+ */
+export function defineCached<TArgs extends any[], TResult>(
+  keyBase: string,
+  fn: AnyAsyncFn<TArgs, TResult>,
+  ttl: number = 600
+): AnyAsyncFn<TArgs, TResult> {
+  return async (...args: TArgs): Promise<TResult> => {
+    // Compose a cache key from base + stringified args
+    const cacheKey = `${keyBase}:${stringify(args)}`;
+
+    // Return cached if available
+    const cached = cache.get<TResult>(cacheKey);
+    if (cached) return cached;
+
+    // Deduplicate: if already pending, return in-progress promise
+    if (pending[cacheKey] !== undefined) return pending[cacheKey];
+
+    // Otherwise, start the fetch, cache, and dedupe
+    pending[cacheKey] = (async () => {
+      const result = await fn(...args);
+      cache.set(cacheKey, result, ttl);
+      return result;
+    })();
+
+    try {
+      return await pending[cacheKey];
+    } finally {
+      delete pending[cacheKey];
+    }
+  };
+}

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -25,6 +25,18 @@ async function isValidChain(
   if (!chainsService.isSupportedChain(targetChain, 'target')) {
     return `target chain ${targetChain} not supported`
   }
+  const originChainDisabled = await chainsService.isDisabledChain(
+    originChain as ChainName
+  )
+  if (originChainDisabled) {
+    return `origin chain ${originChain} disabled`
+  }
+  const targetChainDisabled = await chainsService.isDisabledChain(
+    targetChain as ChainName
+  )
+  if (targetChainDisabled) {
+    return `target chain ${targetChain} disabled`
+  }
 
   // const currencies = await chainsService.getAvailableCurrencies({
   //   originChain,


### PR DESCRIPTION
 merge static and Kima API chain data
- Now includes the `disabled: boolean` prop
- Adds 5 minute TTL for chain data
- Refactored the chain filtering to take into account the dynamic data and disabled state
  - Disabled chains are still considered "supported" (they should be displayed in the frontend)
  - Adds validation for disabled chains in the validation middleware so disabled chains will be rejected with status 400

TODO: frontend changes to show disabled chains but not selectable (greyed out).